### PR TITLE
Remove gh ext

### DIFF
--- a/.config/yadm/bootstrap
+++ b/.config/yadm/bootstrap
@@ -60,13 +60,3 @@ for plugin in "${plugins[@]}" ; do
 done
 
 asdf install
-
-# install github cli extensions
-github_cli_extensions=(
-  "seachicken/gh-poi"
-  "nektos/gh-act"
-)
-
-for ext in "${github_cli_extensions[@]}" ; do
-  gh ext install "https://github.com/${ext}"
-done

--- a/.config/yadm/bootstrap
+++ b/.config/yadm/bootstrap
@@ -68,5 +68,5 @@ github_cli_extensions=(
 )
 
 for ext in "${github_cli_extensions[@]}" ; do
-  gh ext install ${ext}
+  gh ext install "https://github.com/${ext}"
 done


### PR DESCRIPTION
yadmのbootstrap時にgh ext install がキックされ、GitHub Tokenが要求される。しかし、secret情報をfeatureのビルド時に引き継ぐ方法がない（復号化されずに***文字列で渡ってしまう）ので諦める。